### PR TITLE
Not show 1st page with useHash:false

### DIFF
--- a/jquery.pager.js
+++ b/jquery.pager.js
@@ -86,7 +86,11 @@
             options.pages[i] = options.items.slice(startItem, (startItem + options.perPage));
         }
 
-        $(window).trigger("hashchange.pager");
+        if (options.useHash) {
+            $(window).trigger("hashchange.pager");
+        } else {
+            show(options, options.startPage-1);
+        }
         options.init.call(this, options.currentPage + 1, options.totalPages);
     }
 


### PR DESCRIPTION
the content of 1st page is not showing when the config `useHash` is set to false so I added a condition to verify `useHash` and call the first or `startPage` when pager starts.
